### PR TITLE
Remove Cheddar from Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,6 @@ Jump to
 
 ## Tasks
 
-- [Cheddar](https://github.com/nothingmagical/cheddar-ios): Simple & instant task manager 🔥🔥🔥🔥🔥
 - [CloudKit-To-Do-List](https://github.com/anthonygeranio/CloudKit-To-Do-List): Store & retrieve tasks using CloudKit 🔶
 - [RealmToDo](https://github.com/pietbrauer/RealmToDo): A small todo list with Realm integration 🔶
 - Task: Designed to quickly and easily add tasks to your iPhone 🔶


### PR DESCRIPTION
Cheddar states in it's Readme that it is not open source.

https://github.com/nothingmagical/cheddar-ios#cheddar-for-ios

> "**Important:** Cheddar for iOS is no longer maintained by Nothing Magical. It has been sold. Going forward, Cheddar is no longe (sic) open source..."