### PR TITLE
Add Gorillas iTunes link

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1149,6 +1149,7 @@
       "description": "An iPhone (or iPod touch) port of the popular old QBasic game with spunk!",
       "source": "https://github.com/Lyndir/Gorillas",
       "homepage": "http://gorillas.lyndir.com/",
+      "itunes": "https://itunes.apple.com/app/lyndir/gorillas/id302275459",
       "stars": 240
     },
     {

--- a/contents.json
+++ b/contents.json
@@ -1149,7 +1149,7 @@
       "description": "An iPhone (or iPod touch) port of the popular old QBasic game with spunk!",
       "source": "https://github.com/Lyndir/Gorillas",
       "homepage": "http://gorillas.lyndir.com/",
-      "itunes": "https://itunes.apple.com/app/lyndir/gorillas/id302275459",
+      "itunes": "https://itunes.apple.com/app/lyndir/id302275459",
       "stars": 240
     },
     {

--- a/contents.json
+++ b/contents.json
@@ -1149,7 +1149,7 @@
       "description": "An iPhone (or iPod touch) port of the popular old QBasic game with spunk!",
       "source": "https://github.com/Lyndir/Gorillas",
       "homepage": "http://gorillas.lyndir.com/",
-      "itunes": "https://itunes.apple.com/app/lyndir/id302275459",
+      "itunes": "https://itunes.apple.com/app/gorillas/id302275459",
       "stars": 240
     },
     {


### PR DESCRIPTION
@scribblemaniac do you know why this iTunes link fails to `json validate`?

```js
"itunes": "https://itunes.apple.com/app/lyndir/gorillas/id302275459",
```

```
  #/projects/103/itunes
    - reason Forbidden value
```