### PR TITLE
Regional iTunes Links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Feel free to cut and paste the snippet below
     		"category": "Category name",
     		"description": "What this app does",
     		"source": "Link to source, usually GitHub"
-	}
+}
 ```
 
 #### Details
@@ -68,8 +68,20 @@ Feel free to cut and paste the snippet below
 
 - `tags`: List of app attribute tags, use `swift` if the app is written in Swift
 
-#### Examples
+- `itunes`: Link to App Store
 
+  - No regional restriction: the app should not have a region in the URL (`/gb` below)
+
+    - Good: https://itunes.apple.com/app/gorillas/id302275459
+    - Bad:  https://itunes.apple.com/gb/app/gorillas/id302275459
+
+  - If the app is only available in a region, the URL should have a region
+
+	- Good: https://itunes.apple.com/gb/app/closebox-find-closest-postbox/id556364813
+	- Bad:  https://itunes.apple.com/app/closebox-find-closest-postbox/id556364813
+
+
+#### Examples
 
 - https://github.com/dkhamsing/open-source-ios-apps/pull/281
 - https://github.com/dkhamsing/open-source-ios-apps/pull/281/files

--- a/contents.json
+++ b/contents.json
@@ -3798,14 +3798,14 @@
       "description": "Make free audio/video calls and text messages.",
       "source": "https://www.linphone.org/technical-corner/linphone/downloads",
       "homepage": "https://www.linphone.org/",
-      "itunes": "https://itunes.apple.com/us/app/linphone/id360065638"
+      "itunes": "https://itunes.apple.com/app/linphone/id360065638"
     },
     {
       "title": "Molecules",
       "category": "science",
       "description": "Visualize molecules in 3D.",
       "source": "http://www.sunsetlakesoftware.com/molecules",
-      "itunes": "https://itunes.apple.com/us/app/molecules/id284943090"
+      "itunes": "https://itunes.apple.com/app/molecules/id284943090"
     },
     {
       "title": "Task Coach",
@@ -3820,7 +3820,7 @@
       "category": "games",
       "description": "A real-time physical game where you build your kingdom while crushing your opponents.",
       "source": "https://github.com/bryceredd/CastleHassle",
-      "itunes": "https://itunes.apple.com/us/app/castle-hassle/id524566068"
+      "itunes": "https://itunes.apple.com/app/castle-hassle/id524566068"
     },
     {
       "title": "Skeleton Key",
@@ -3872,14 +3872,14 @@
       "description": "Blast your way through waves of pterodactyls. Also has a detailed writeup on how it's made.",
       "source": "https://github.com/shaunlebron/PterodactylAttack",
       "homepage": "https://shaunlebron.github.io/pteroattack.com/",
-      "itunes": "https://itunes.apple.com/us/app/pterodactyl-attack/id786862892"
+      "itunes": "https://itunes.apple.com/app/pterodactyl-attack/id786862892"
     },
     {
       "title": "Neocom for EVE Online",
       "category": "games",
       "description": "The character management tool for EveOnline MMORG.",
       "source": "https://github.com/mrdepth/Neocom",
-      "itunes": "https://itunes.apple.com/us/app/eveuniverse/id418895101",
+      "itunes": "https://itunes.apple.com/app/eveuniverse/id418895101",
       "stars": 56
     }
   ]


### PR DESCRIPTION
Originally meant to update the convert script to add 🌐  to the readme for regional itunes links but there are not enough of them to warrant this right now.

---

Close #321

Not updating pull request template.. it's long enough but "we" the collaborators should ensure the `itunes` link is [good](https://github.com/dkhamsing/open-source-ios-apps/pull/322/commits/ad5c08dd9b5e8432b8bece654a210baa7662cfb8).