### PR TITLE
Change `ger` language code to `deu`

### DIFF
--- a/.github/osia_convert.rb
+++ b/.github/osia_convert.rb
@@ -121,7 +121,7 @@ end
 
 def output_flag(lang)
   case lang
-  when 'ger'
+  when 'deu'
     '🇩🇪'
   when 'jpn'
     '🇯🇵'

--- a/contents.json
+++ b/contents.json
@@ -5196,7 +5196,7 @@
         "apple-tv"
       ],
       "description": "Watch Public German Broadcast/TV company streams",
-      "lang": "ger",
+      "lang": "deu",
       "license": "gpl-2.0",
       "source": "https://github.com/omichde/Telemat-tvOS",
       "stars": 4,


### PR DESCRIPTION
The ISO 639-2 language codes have two codes B and T. According to [Wikipedia](https://en.wikipedia.org/wiki/ISO_639-2), B is more of a legacy set based off of the English names, while the T set is based off on the native name. Additionally it says that T codes are generally favored. So based off of that, and the fact we are already using the T code for Chinese, this PR makes all of the langauges we have use T codes. This only required the changing of the German code, but will also need to be kept in mind when adding new languages in the future.