### PR TITLE
Removed the itunes link of Dono

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -7624,7 +7624,6 @@
       ],
       "description": "Password derivation tool",
       "homepage": "https://dono-app.github.io/",
-      "itunes": "https://itunes.apple.com/app/id1092920229",
       "source": "https://github.com/dono-app/dono-ios",
       "tags": [
         "swift"


### PR DESCRIPTION
<!-- Thanks for contributing to open-source-ios-apps 😊

⚠️ Please do not edit the README, instead make changes to contents.json

To create a new category, please open an issue (see CONTRIBUTING) -->

<!-- When making an addition: -->

1. [ ] Project URL:
2. [ ] Update contents.json instead of README 
3. [ ] One project per pull request
4. [ ] Avoid iOS or open-source in description as it is assumed
5. [ ] Use this commit title format if applicable: Add app-name by @github-username
6. [ ] Use approved format for your entry

<!-- Approved Format

{
            "title": "Name of the app",
            "category-ids": ["Category id"],
            "description": "What this app does",
            "source": "Link to source, usually GitHub",
            "screenshots": ["http://something.com/image.png"],
            "date_added": "Aug 6 2016",
            "suggested_by": "@github_username"
}

For more information, read https://github.com/dkhamsing/open-source-ios-apps/blob/master/.github/CONTRIBUTING.md

-->

Dono is removed from the iTunes store. Will add the iTunes url back once it's online again :smile: