### PR TITLE
Fix Rocket.Chat App Store link

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1382,7 +1382,7 @@
       "description": "Meteor chat platform app",
       "license": "mit",
       "source": "https://github.com/RocketChat/Rocket.Chat.iOS",
-      "itunes": "https://itunes.apple.com/app/rocket.chat/id1028869439",
+      "itunes": "https://itunes.apple.com/app/rocket-chat/id1148741252",
       "tags": [
         "swift"
       ],

--- a/contents.json
+++ b/contents.json
@@ -1906,7 +1906,7 @@
       ],
       "description": "Bitcoin wallet",
       "license": "mit",
-      "source": "https://github.com/breadwallet/breadwallet",
+      "source": "https://github.com/breadwallet/breadwallet-legacy",
       "itunes": "https://itunes.apple.com/app/breadwallet/id885251393",
       "stars": 46,
       "date_added": "Wed Jul 8 06:45:27 2015 -0700",


### PR DESCRIPTION
Link was pointing to the Cordova version of Rocket.Chat instead of the native one.