### PR TITLE
Add Pass for iOS by @mssun

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -12340,6 +12340,30 @@
       "stars": 66
     },
     {
+      "title": "Pass for iOS",
+      "description": "Client compatible with the Pass command line application",
+      "category-ids": [
+        "password"
+      ],
+      "source": "https://github.com/mssun/passforios",
+      "itunes": "https://itunes.apple.com/app/pass-password-store/id1205820573",
+      "homepage": "https://mssun.github.io/passforios",
+      "screenshots": [
+        "https://github.com/mssun/passforios/raw/master/screenshot/screenshot1.png?raw=true",
+        "https://github.com/mssun/passforios/raw/master/screenshot/screenshot2.png?raw=true",
+        "https://github.com/mssun/passforios/raw/master/screenshot/screenshot3.png?raw=true"
+      ],
+      "tags": [
+        "swift",
+        "objective-git",
+        "ObjectivePGP"
+      ],
+      "license": "mit",
+      "date_added": "Apr 13 2019",
+      "suggested_by": "@SimplyDanny",
+      "stars": 607
+    },
+    {
       "title": "try! Swift NYC",
       "source": "https://github.com/tryswift/trySwiftNYC",
       "category-ids": [


### PR DESCRIPTION
The app [pass](https://github.com/davidjb/pass-ios) has been deprecated (#725). Its successor is [Pass for iOS](https://github.com/mssun/passforios).

1. [x] Project URL:
2. [x] Update contents.json instead of README 
3. [x] One project per pull request
4. [x] Screenshot included 
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use this commit title format if applicable: Add app-name by @github-username
7. [x] Use approved format for your entry