### PR TITLE
Add Mattermost by @jasonblais

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -20285,7 +20285,7 @@
         "alamofire",
         "swiftyjson"
       ],
-      "date_added": "May 17 20202",
+      "date_added": "May 17 2020",
       "suggested_by": "@dkhamsing"
     },
     {

--- a/contents.json
+++ b/contents.json
@@ -20334,7 +20334,7 @@
         "https://user-images.githubusercontent.com/13119842/82450764-1c9e1b00-9a7b-11ea-83d2-b835bf51c727.png",
         "https://user-images.githubusercontent.com/13119842/82450847-38092600-9a7b-11ea-92a8-52cf92fb137b.png",
         "https://user-images.githubusercontent.com/13119842/82450869-3e979d80-9a7b-11ea-81ea-0780c7a612f7.png",
-        "https://user-images.githubusercontent.com/13119842/82450896-47886f00-9a7b-11ea-92f4-da9e5553f469.png",
+        "https://user-images.githubusercontent.com/13119842/82450896-47886f00-9a7b-11ea-92f4-da9e5553f469.png"
       ],
       "stars": 1083,
       "date_added": "May 20 2020",

--- a/contents.json
+++ b/contents.json
@@ -20285,7 +20285,7 @@
         "alamofire",
         "swiftyjson"
       ],
-      "date_added": "May 17 2020",
+      "date_added": "May 17 20202",
       "suggested_by": "@dkhamsing"
     },
     {
@@ -20316,6 +20316,29 @@
       ],
       "date_added": "May 18 2020",
       "suggested_by": "@dkhamsing"
+    },
+    {
+      "title": "Mattermost",
+      "category-ids": [
+        "communication",
+        "react-native"
+      ],
+      "description": "Secure messaging platform for DevOps teams",
+      "license": "apache-2.0",
+      "source": "https://github.com/mattermost/mattermost-mobile",
+      "itunes": "https://apps.apple.com/us/app/mattermost/id1257222717",
+      "tags": [
+        "react-native"
+      ],
+      "screenshots": [
+        "https://user-images.githubusercontent.com/13119842/82450764-1c9e1b00-9a7b-11ea-83d2-b835bf51c727.png",
+        "https://user-images.githubusercontent.com/13119842/82450847-38092600-9a7b-11ea-92a8-52cf92fb137b.png",
+        "https://user-images.githubusercontent.com/13119842/82450869-3e979d80-9a7b-11ea-81ea-0780c7a612f7.png",
+        "https://user-images.githubusercontent.com/13119842/82450896-47886f00-9a7b-11ea-92f4-da9e5553f469.png",
+      ],
+      "stars": 1083,
+      "date_added": "May 20 2020",
+      "suggested_by": "@jasonblais"
     }
   ]
 }


### PR DESCRIPTION
Add Mattermost as a Communications app, by @jasonblais

1. [X] Project URL: https://github.com/mattermost/mattermost-mobile
2. [X] Update contents.json instead of README 
3. [X] One project per pull request
4. [X] Screenshot included 
5. [X] Avoid iOS or open-source in description as it is assumed
6. [X] Use this commit title format if applicable: Add app-name by @github-username
7. [X] Use approved format for your entry
