### PR TITLE
Update tags of 2FA apps

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -5447,6 +5447,7 @@
       ],
       "tags": [
         "swift",
+        "2fa",
         "moa"
       ],
       "stars": 307
@@ -9375,7 +9376,8 @@
         "password"
       ],
       "tags": [
-        "objc"
+        "swift",
+        "2fa"
       ],
       "description": "Simple two-factor authentication with a clean UI",
       "source": "https://github.com/mattrubin/authenticator",
@@ -20117,7 +20119,8 @@
         "https://user-images.githubusercontent.com/11808903/80574717-a457b300-8a02-11ea-915e-db7cd98740f2.png"
       ],
       "tags": [
-        "dart"
+        "react-native",
+        "2fa"
       ],
       "stars": 70
     },


### PR DESCRIPTION
Updated the tags of 2FA apps.
[Authenticator](https://github.com/mattrubin/authenticator) is written by swift and [einmal](https://github.com/incipher/einmal ) is by React Native.

<!-- Thanks for contributing to open-source-ios-apps 😊

⚠️ Please do not edit the README, instead make changes to contents.json

To create a new category, please open an issue (see CONTRIBUTING) -->

<!-- When making an addition: -->

1. [x] Project URL:
2. [x] Update contents.json instead of README 
3. [x] One project per pull request
4. [x] Screenshot included 
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use this commit title format if applicable: Add app-name by @github-username
7. [x] Use approved format for your entry

<!-- Approved Format

{
            "title": "Name of the app",
            "category-ids": ["Category id"],
            "description": "What this app does",
            "source": "Link to source, usually GitHub",
            "screenshots": ["http://something.com/image.png"],
            "date_added": "Aug 6 2016",
            "suggested_by": "@github_username"
}

For more information, read https://github.com/dkhamsing/open-source-ios-apps/blob/master/.github/CONTRIBUTING.md

-->
