### PR TITLE
Include contents.json in netlify ignore.

### DIFF
--- a/gatsby/netlify.toml
+++ b/gatsby/netlify.toml
@@ -2,5 +2,6 @@
   package = "netlify-plugin-gatsby-cache"
 
 [build]
+  ignore = "git diff —quiet HEAD^ HEAD . ../contents.json"
   publish = "public/"
   command = "head -n 2 ../contents.json && yarn run build"


### PR DESCRIPTION
This will hopefully solve the netlify problem. It targets the `gatsby/` directory, and so by default, I believe it ignores any commits that don't include changes to that directory. Hopefully this change means that it will rebuild whenever `contents.json` or the `gatsby/` directory change.