### PR TITLE
Validate JSON

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
         - ~/.go_workspace
         - ~/.gradle
         - ~/.cache/bower
-    #- run: sudo pip install json-spec
-    #- run: json validate --schema-file=.github/schema.json --document-file=contents.json
+    - run: gem install json_schema
+    - run: validate-schema .github/schema.json contents.json
     - run: ruby .github/osia_validate_categories.rb
     - store_test_results:
         path: /tmp/circleci-test-results


### PR DESCRIPTION
Started having an issue with `pip` https://app.circleci.com/pipelines/github/dkhamsing/open-source-ios-apps/785/workflows/fdf1a0f5-6f51-42b0-9fd7-a2284fb53db8/jobs/3656

With this change, JSON validation uses https://rubygems.org/gems/json_schema

Testing validation ✅ https://app.circleci.com/pipelines/github/dkhamsing/open-source-ios-apps/789/workflows/82f16abb-b1eb-4a88-accc-f9a8b16e28c5/jobs/3661