### PR TITLE
Update Blink Shell App Store link

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -11570,7 +11570,7 @@
       "license": "gpl-3.0",
       "description": "Mobile shell terminal based on Mosh",
       "source": "https://github.com/blinksh/blink",
-      "itunes": "https://apps.apple.com/app/id1156707581",
+      "itunes": "https://apps.apple.com/us/app/blink-shell-build-code/id1594898306",
       "screenshots": [
         "https://is4-ssl.mzstatic.com/image/thumb/Purple113/v4/e1/44/bf/e144bfb0-5397-6e9f-7e94-e7303af10e93/pr_source.png/626x0w.jpg",
         "https://is2-ssl.mzstatic.com/image/thumb/Purple123/v4/b8/a3/3f/b8a33f92-cf60-03ec-a8c2-ff3cdc222f80/pr_source.png/626x0w.jpg",

--- a/contents.json
+++ b/contents.json
@@ -11570,7 +11570,7 @@
       "license": "gpl-3.0",
       "description": "Mobile shell terminal based on Mosh",
       "source": "https://github.com/blinksh/blink",
-      "itunes": "https://apps.apple.com/us/app/blink-shell-build-code/id1594898306",
+      "itunes": "https://apps.apple.com/app/blink-shell-build-code/id1594898306",
       "screenshots": [
         "https://is4-ssl.mzstatic.com/image/thumb/Purple113/v4/e1/44/bf/e144bfb0-5397-6e9f-7e94-e7303af10e93/pr_source.png/626x0w.jpg",
         "https://is2-ssl.mzstatic.com/image/thumb/Purple123/v4/b8/a3/3f/b8a33f92-cf60-03ec-a8c2-ff3cdc222f80/pr_source.png/626x0w.jpg",


### PR DESCRIPTION
Blink Shell version 14 is "grandfathered" as described on its [Store page](https://apps.apple.com/app/blink-shell-14-legacy/id1156707581).

More information on their [blog](https://docs.blink.sh/migration).

Updated the link with the new one.