### PR TITLE
Archive TelemetryViewer

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -29536,7 +29536,7 @@
       ],
       "tags": [
         "swift",
-        "swiftui"
+        "swiftui", "archive"
       ],
       "license": "mit",
       "source": "https://github.com/TelemetryDeck/TelemetryViewer",


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/TelemetryDeck/TelemetryViewer
2. [x] Add `archive` tag
