### PR TITLE
Archive Corona Warn App

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -22602,7 +22602,7 @@
       "source": "https://github.com/corona-warn-app/cwa-app-ios",
       "itunes": "https://apps.apple.com/de/app/corona-warn-app/id1512595757",
       "tags": [
-        "swift"
+        "swift", "archive"
       ],
       "lang": "deu",
       "screenshots": [


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/corona-warn-app/cwa-app-ios
2. [x] Add `archive` tag
