### PR TITLE
Archive NHS Covid-19

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -25172,7 +25172,7 @@
         "contact-tracing"
       ],
       "tags": [
-        "swift"
+        "swift", "archive"
       ],
       "screenshots": [
         "https://github.com/dkhamsing/open-source-ios-apps/assets/4723115/065bc847-e492-440f-9f76-f80ce18d4200"


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/ukhsa-collaboration/covid-19-app-ios-ag-public
2. [x] Add `archive` tag
