### PR TITLE
Archive Canada - covid alert

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -24174,7 +24174,7 @@
         "react-native"
       ],
       "tags": [
-        "react-native"
+        "react-native", "archive"
       ],
       "lang": "fra",
       "source": "https://github.com/cds-snc/covid-alert-app",


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/cds-snc/covid-alert-app
2. [x] Add `archive` tag
