### PR TITLE
Add 'archive' tag to CastVideos

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -16149,7 +16149,7 @@
       ],
       "description": "Sender app to be used as the starting for Google Cast",
       "tags": [
-        "swift"
+        "swift", "archive"
       ],
       "license": "apache-2.0",
       "date_added": "Jul 10 2017",


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/googlecast/CastVideos-ios
2. [x] Add `archive` tag
