### PR TITLE
Add 'archive' tag to SwiftTermApp

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -28817,7 +28817,7 @@
         "terminal"
       ],
       "tags": [
-        "swiftui"
+        "swiftui", "archive"
       ],
       "license": "mit",
       "description": "Terminal emulator and SSH client",


### PR DESCRIPTION
## Archive a project
1. [x] Project URL: https://github.com/migueldeicaza/SwiftTermApp
2. [x] Add `archive` tag
