### PR TITLE
Update screenshot URLs for try! Swift Tokyo

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -14512,8 +14512,7 @@
         "event"
       ],
       "screenshots": [
-        "https://cloud.githubusercontent.com/assets/4190298/23140345/534ae20c-f7b1-11e6-8584-b65aded1f59e.png",
-        "https://cloud.githubusercontent.com/assets/4190298/23140344/53463e82-f7b1-11e6-8d84-c0cedcc930b1.png"
+        "https://github.com/user-attachments/assets/b74ae3cc-48e3-40a4-beea-fbb118dca413"
       ],
       "itunes": "https://apps.apple.com/app/try-tokyo-2026/id6479317240",
       "license": "mit",


### PR DESCRIPTION
<img width="1715" height="1192" alt="Screenshot 2026-04-30 at 9 43 42 AM" src="https://github.com/user-attachments/assets/b74ae3cc-48e3-40a4-beea-fbb118dca413" />

#2173 