### PR TITLE
Add BeeCount by @TNT-Likely

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -34152,6 +34152,26 @@
       "suggested_by": "@ccleberg",
       "stars": 1,
       "updated": "2026-04-22 19:12:01 UTC"
+    },
+    {
+      "title": "BeeCount",
+      "category-ids": [
+        "finance"
+      ],
+      "description": "Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3)",
+      "source": "https://github.com/TNT-Likely/BeeCount",
+      "itunes": "https://apps.apple.com/app/id6754611670",
+      "screenshots": [
+        "https://raw.githubusercontent.com/TNT-Likely/BeeCount/main/demo/preview/en/01-home.png",
+        "https://raw.githubusercontent.com/TNT-Likely/BeeCount/main/demo/preview/en/04-chart-analysis.png",
+        "https://raw.githubusercontent.com/TNT-Likely/BeeCount/main/demo/preview/en/06-profile.png"
+      ],
+      "tags": [
+        "flutter",
+        "dart"
+      ],
+      "date_added": "May 6 2026",
+      "suggested_by": "@TNT-Likely"
     }
   ]
 }


### PR DESCRIPTION
## Add a project

1. [x] Project URL: https://github.com/TNT-Likely/BeeCount
2. [x] Update contents.json instead of README
3. [x] One project per pull request
4. [x] Screenshot included
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use this commit title format if applicable: Add app-name by @github-username
7. [x] Use approved format for your entry

**About BeeCount**

BeeCount is a privacy-first cross-platform expense tracker built with Flutter. iOS app is available on the App Store; offline-first; supports self-hostable cloud sync (BeeCount Cloud) plus iCloud / Supabase / WebDAV / S3 backends.

- App Store: https://apps.apple.com/app/id6754611670
- Source: https://github.com/TNT-Likely/BeeCount (~1.5k★, 200+ forks, active)
- Tags: `flutter`, `dart`
- Category: `finance`

**Affiliation disclosure**: I am the author and primary maintainer of BeeCount (@TNT-Likely).

**Note on license**: BeeCount uses a custom commercial source-available license (free for personal/non-commercial use; commercial use requires paid license) — I omitted the `license` field since it's not a standard SPDX identifier. Happy to adjust if a different value is preferred.