### PR TITLE
Add 'archive' tag to TabDump

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -5167,7 +5167,7 @@
         "https://github.com/dkhamsing/TabDump/raw/master/assets/screenshots/screenshot.png"
       ],
       "tags": [
-        "afnetworking"
+        "afnetworking", "archive"
       ],
       "description": "TabDump news",
       "license": "mit",


### PR DESCRIPTION
The source links are unavailable, and the app has not been updated for 9 years.

## Archive a project
1. [x] Project URL: https://github.com/dkhamsing/TabDump
2. [x] Add `archive` tag
