### PR TITLE
Add 'archive' tag to Flutter News App

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -21147,7 +21147,7 @@
       "source": "https://github.com/theindianappguy/FlutterNewsApp",
       "tags": [
         "flutter",
-        "dart"
+        "dart", "archive"
       ],
       "license": "other",
       "date_added": "Apr 21 2020",


### PR DESCRIPTION
404 Error - 

## Archive a project
1. [x] Project URL: https://github.com/theindianappguy/FlutterNewsApp
2. [x] Add `archive` tag
