### PR TITLE
Add 'archive' tag to DOOM Classic 2

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2897,7 +2897,7 @@
         "game"
       ],
       "tags": [
-        "objc"
+        "objc", "archive"
       ],
       "source": "https://github.com/id-Software/DOOM-IOS2",
       "itunes": "https://apps.apple.com/app/doom-ii-rpg/id354051766",


### PR DESCRIPTION
No commits for 13+ years.

## Archive a project
1. [x] Project URL: https://github.com/id-Software/DOOM-IOS2
2. [x] Add `archive` tag
