### PR TITLE
Add 'archive' tag to UitzendingGemist

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -9754,7 +9754,7 @@
       "license": "apache-2.0",
       "source": "https://github.com/4np/UitzendingGemist",
       "tags": [
-        "swift"
+        "swift", "archive"
       ],
       "screenshots": [
         "https://cloud.githubusercontent.com/assets/1049693/18724167/ba26d9ba-803b-11e6-9c76-2f44c47d2dee.png"


### PR DESCRIPTION
No commits in 9+ years.

## Archive a project
1. [x] Project URL: https://github.com/4np/UitzendingGemist
2. [x] Add `archive` tag
