### PR TITLE
Add 'archive' tag to RaceMe

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -12142,7 +12142,8 @@
       ],
       "tags": [
         "swift",
-        "parse"
+        "parse",
+        "archive"
       ],
       "license": "other",
       "stars": 614,


### PR DESCRIPTION
The repository is unavailable

## Archive a project
1. [x] Project URL: https://github.com/enochng1/RaceMe
2. [x] Add `archive` tag
