### PR TITLE
Add Dredfit by @dredfort42

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -34419,6 +34419,24 @@
       "stars": 47,
       "updated": "2026-07-19 14:39:42 UTC"
     },
-    {"title": "Dredfit", "description": "Adaptive bodyweight workout trainer that adjusts to how your last session went", "source": "https://github.com/dredfort42/dredfit", "itunes": "https://apps.apple.com/app/id6791739610", "category-ids": ["fitness"], "tags": ["swift", "swiftui"], "license": "gpl-3.0", "date_added": "Jul 26 2026", "suggested_by": "@dredfort42"}
+    {
+      "title": "Dredfit",
+      "category-ids": [
+        "fitness"
+      ],
+      "tags": [
+        "swift",
+        "swiftui"
+      ],
+      "description": "Adaptive bodyweight workout trainer that adjusts to how your last session went",
+      "source": "https://github.com/dredfort42/dredfit",
+      "itunes": "https://apps.apple.com/app/id6791739610",
+      "license": "gpl-3.0",
+      "screenshots": [
+        "https://raw.githubusercontent.com/dredfort42/dredfit/main/appstore/screenshots/en/s1.png"
+      ],
+      "date_added": "Jul 26 2026",
+      "suggested_by": "@dredfort42"
+    }
   ]
 }

--- a/contents.json
+++ b/contents.json
@@ -34418,6 +34418,7 @@
       "suggested_by": "@GlowOnyx-d",
       "stars": 47,
       "updated": "2026-07-19 14:39:42 UTC"
-    }
+    },
+    {"title": "Dredfit", "description": "Adaptive bodyweight workout trainer that adjusts to how your last session went", "source": "https://github.com/dredfort42/dredfit", "itunes": "https://apps.apple.com/app/id6791739610", "category-ids": ["fitness"], "tags": ["swift", "swiftui"], "license": "gpl-3.0", "date_added": "Jul 26 2026", "suggested_by": "@dredfort42"}
   ]
 }


### PR DESCRIPTION
## Add a project
1. [x] Project URL: https://github.com/dredfort42/dredfit
2. [x] Update contents.json instead of README
3. [x] One project per pull request
4. [x] Screenshot included
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use this commit title format if applicable: Add app-name by @github-username
7. [x] Use approved format for your entry

Dredfit is an adaptive bodyweight trainer. It starts at a conservative minimum and adjusts every next workout from a single question after the previous one — no onboarding quiz, no account, no network calls. GPLv3, 215 automated tests.