### PR TITLE
Add RAYN Weather by @qh-work

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -534,6 +534,26 @@
       "updated": "2016-07-12 05:53:50 UTC"
     },
     {
+      "title": "RAYN Weather",
+      "category-ids": [
+        "apple-tv",
+        "weather"
+      ],
+      "tags": [
+        "swift",
+        "swiftui",
+        "tvos"
+      ],
+      "description": "Live weather, radar, air quality, astronomy, and marine conditions for Apple TV",
+      "license": "mit",
+      "source": "https://github.com/qh-work/RAYN",
+      "screenshots": [
+        "https://raw.githubusercontent.com/qh-work/RAYN/main/docs/media/screenshots/01-current-weather.png"
+      ],
+      "date_added": "Aug 17, 2026",
+      "suggested_by": "@qh-work"
+    },
+    {
       "title": "BaiduFM",
       "category-ids": [
         "apple-watch"


### PR DESCRIPTION
## Add a project
1. [x] Project URL: https://github.com/qh-work/RAYN
2. [x] Update contents.json instead of README
3. [x] One project per pull request
4. [x] Screenshot included
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use the requested commit title format
7. [x] Use the approved entry format

RAYN Weather is a native SwiftUI weather app for Apple TV with live forecasts, precipitation radar, air quality, sun and moon information, optional marine conditions, and nine localized interface languages.