### PR TITLE
Update DailyVox description

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -34266,7 +34266,7 @@
     },
     {
       "title": "DailyVox",
-      "description": "AI Voice Diary",
+      "description": "Voice journal that transcribes on-device and holds no internet permission",
       "category-ids": [
         "health"
       ],


### PR DESCRIPTION
Small change to my own entry.

The description read `AI Voice Diary`, which does not distinguish it from anything else in the category. Replacing it with what the app actually does differently: transcription runs on device via `SFSpeechRecognizer` with `requiresOnDeviceRecognition`, and the app declares no networking entitlement, so it cannot upload anything.

```diff
-"description": "AI Voice Diary",
+"description": "Voice journal that transcribes on-device and holds no internet permission",
```

One line in `contents.json`; JSON validated. Source is MIT at intrepidkarthi/dailyvox.

Worth disclosing: the app's Twin analysis engine is a separate closed-source Swift package, so the public repo is readable but not buildable standalone. Happy to have the entry removed if that puts it outside the list's scope.