### PR TITLE
Add Conduck by @peterkrueck

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -34711,6 +34711,28 @@
       ],
       "date_added": "Aug 27 2026",
       "suggested_by": "@hajar-benhadj"
+    },
+    {
+      "title": "Conduck",
+      "category-ids": [
+        "productivity",
+        "apple-watch",
+        "macos",
+        "swiftui"
+      ],
+      "tags": [
+        "swift",
+        "swiftui"
+      ],
+      "description": "Native voice and text client for your self-hosted or BYO-key AI, on iPhone, iPad, Mac, Apple Watch and CarPlay",
+      "source": "https://github.com/GigaDuckAI/conduck",
+      "itunes": "https://apps.apple.com/app/id6773045286",
+      "license": "apache-2.0",
+      "screenshots": [
+        "https://conduck.com/media/conduck-film-poster-v1.jpg"
+      ],
+      "date_added": "Sep 2 2026",
+      "suggested_by": "@peterkrueck"
     }
   ]
 }


### PR DESCRIPTION
## Add a project
1. [x] Project URL: https://github.com/GigaDuckAI/conduck
2. [x] Update contents.json instead of README
3. [x] One project per pull request
4. [x] Screenshot included
5. [x] Avoid iOS or open-source in description as it is assumed
6. [x] Use this commit title format if applicable: Add app-name by @github-username
7. [x] Use approved format for your entry

Conduck is a native SwiftUI client for a self-hosted or BYO-key AI (OpenAI-compatible servers, Ollama, LM Studio, OpenRouter, agent gateways). Voice and text on iPhone, iPad, Mac, Apple Watch and CarPlay; no account, no intermediary server. Apache-2.0, on the App Store: https://apps.apple.com/app/id6773045286

🤖 Generated with [Claude Code](https://claude.com/claude-code)